### PR TITLE
Fix up: Absent is not None

### DIFF
--- a/schemamodels/__init__.py
+++ b/schemamodels/__init__.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
-from dataclasses import make_dataclass, field, fields as fs, asdict
+from dataclasses import make_dataclass, field, fields as fs, asdict, Field
+from dataclasses import MISSING
 from re import sub
 import importlib
 from operator import gt, ge, lt, le, mod, xor, not_, contains

--- a/schemamodels/__init__.py
+++ b/schemamodels/__init__.py
@@ -190,6 +190,7 @@ class SchemaModelFactory:
             else:
                 print('not a built-in')
                 entry += (1, )
+
             if k in required_fields:
                 field_spec.update(init=True)
                 field_spec.update(default_factory=object)
@@ -198,7 +199,8 @@ class SchemaModelFactory:
                 field_spec.update(default=v.get('default'))
                 field_spec.pop('default_factory', None)
             else:
-                field_spec.pop('default', None)
+                field_spec.update(default_factory=str)
+                # field_spec.pop('default', None)
 
 
             field_meta.update(generate_functors(v))
@@ -206,7 +208,8 @@ class SchemaModelFactory:
 
             entry += (field(**field_spec), )
 
-            if v.get('type', None):
+            print(entry)
+            if not hasattr(entry, 'default'):
                 fields.appendleft(entry)
             else:
                 fields.append(entry)

--- a/schemamodels/__init__.py
+++ b/schemamodels/__init__.py
@@ -219,7 +219,7 @@ class SchemaModelFactory:
             namespace={
                 '_errorhandler': self.error_handler.apply,
                 '_renderer': self.renderer.apply,
-                'tocsv': lambda self, header=False: f'{",".join(asdict(self).keys())}\n{",".join(asdict(self).values())}' if header else ",".join(asdict(self).values()),
+                'tocsv': lambda self, header=False, fields=schema['properties'].keys(): f'{",".join(fields)}\n{",".join(map(lambda i: asdict(self)[i], fields))}' if header else ",".join(map(lambda i: asdict(self)[i], fields)),
                 'tolist': lambda self: list(asdict(self).values()),
                 'todict': lambda self: asdict(self),
                 '__post_init__': lambda self: constraints(self)._errorhandler(self)._renderer(self)

--- a/schemamodels/__init__.py
+++ b/schemamodels/__init__.py
@@ -162,8 +162,8 @@ class SchemaModelFactory:
             return False
         else:
             klassname = generate_classname(schema.get('title'))
-        fields = list()
-        fields_with_defaults = list()
+        fields = deque()
+        fields_with_defaults = deque()
         required_fields = schema.get('required', [])
         if schema.get('anyOf', None):  # Top-level anyOf
             funcs = [generate_functors(s) for s in schema['anyOf']]
@@ -190,7 +190,6 @@ class SchemaModelFactory:
             else:
                 print('not a built-in')
                 entry += (1, )
-                field_spec.update(default=str)
             if k in required_fields:
                 field_spec.update(init=True)
                 field_spec.update(default_factory=object)
@@ -206,7 +205,11 @@ class SchemaModelFactory:
             field_spec.update(metadata=field_meta)
 
             entry += (field(**field_spec), )
-            fields.append(entry)
+
+            if v.get('type', None):
+                fields.appendleft(entry)
+            else:
+                fields.append(entry)
 
         dklass = partial(
             make_dataclass,

--- a/schemamodels/__init__.py
+++ b/schemamodels/__init__.py
@@ -192,24 +192,22 @@ class SchemaModelFactory:
                 print('not a built-in')
                 entry += (1, )
 
-            if k in required_fields:
-                field_spec.update(init=True)
-                field_spec.update(default_factory=object)
-
             if 'default' in v.keys():
-                field_spec.update(default=v.get('default'))
+                field_spec.update(default=v.get('default', Field))
                 field_spec.pop('default_factory', None)
             else:
-                field_spec.update(default_factory=str)
-                # field_spec.pop('default', None)
-
+                field_spec.update(default_factory=DEFAULT_FACTORIES.get(v.get('type'), str))
 
             field_meta.update(generate_functors(v))
             field_spec.update(metadata=field_meta)
 
+            if k in required_fields:
+                field_spec.update(default_factory=MISSING)
+                field_spec.update(default=MISSING)
+
             entry += (field(**field_spec), )
 
-            print(entry)
+            # print(entry)
             if not hasattr(entry, 'default'):
                 fields.appendleft(entry)
             else:

--- a/tests.py
+++ b/tests.py
@@ -78,6 +78,8 @@ def test_enforce_required():
 
 
     req = RequiredSchema(brand_name="wally")
+    assert req.brand_name is not None
+    assert req.brand_name != ''
 
 
     with pytest.raises(TypeError):

--- a/tests.py
+++ b/tests.py
@@ -41,7 +41,8 @@ def test_absent_is_not_none():
     except exceptions.RequiredPropertyViolation:
         assert False
 
-    AbsentSchema(provider_id=1)
+    result = AbsentSchema(provider_id=1)
+    assert result.brand_name is ''
 
 
 def test_enforce_required():
@@ -75,9 +76,13 @@ def test_enforce_required():
     except exceptions.RequiredPropertyViolation:
         assert False
 
-    with pytest.raises(exceptions.ValueTypeViolation):
+
+    req = RequiredSchema(brand_name="wally")
+
+
+    with pytest.raises(TypeError):
         RequiredSchema()
-    with pytest.raises(exceptions.ValueTypeViolation):
+    with pytest.raises(TypeError):
         RequiredSchema(provider_id=1)
 
 

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,36 @@ from schemamodels import generate_functors
 import pytest
 
 
+def test_absent_is_not_none():
+    test = '''
+    {
+        "$id": "https://schema.dev/fake-schema.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "absent-schema",
+        "description": "",
+        "type": "object",
+        "properties": {
+            "provider_id": {
+              "description": "this is a description",
+              "type": "integer"
+            },
+            "brand_name": {
+              "type": "string"
+            }
+        }
+    }
+    '''
+    t = json.loads(test)
+    sm = SchemaModelFactory()
+
+    try:
+        assert sm.register(t)
+        from schemamodels.dynamic import AbsentSchema
+    except exceptions.RequiredPropertyViolation:
+        assert False
+
+    AbsentSchema(provider_id=1)
+
 
 def test_enforce_required():
     test = '''
@@ -47,6 +77,7 @@ def test_enforce_required():
 
     with pytest.raises(exceptions.ValueTypeViolation):
         RequiredSchema()
+    with pytest.raises(exceptions.ValueTypeViolation):
         RequiredSchema(provider_id=1)
 
 
@@ -589,7 +620,7 @@ def test_enum_support():
 
 
 @pytest.mark.export
-def test_enum_support():
+def test_export_funcs():
     enum = '''
     {
         "$id": "https://schema.dev/fake-schema.schema.json",

--- a/tests.py
+++ b/tests.py
@@ -652,7 +652,8 @@ def test_export_funcs():
 
     EnumSchema = getattr(lib, 'EnumSchema')
     e = EnumSchema(handiness="left", brand_name="abcd")
-    assert e.tocsv() == "left,abcd"
+    assert e.tocsv(fields=['handiness', 'brand_name']) == "left,abcd"
     assert e.tocsv(header=True) == "handiness,brand_name\nleft,abcd"
     assert e.todict() == {"handiness": "left", "brand_name": "abcd"}
-    assert e.tolist() == ["left", "abcd"]
+    assert 'left' in e.tolist()
+    assert 'abcd' in e.tolist()


### PR DESCRIPTION
This PR clears up some confusion on how absent fields should be handled relative to the usage of the "required" JSON keyword:

1. The usage of Python dataclasses implies [additionalProperties: false](https://json-schema.org/understanding-json-schema/reference/object.html?highlight=additionalproperties#id5)
2. When declared properties are missing from instantiation, the default_factory should match the property field.

Additionally, this closes #45 